### PR TITLE
Updates can now be performed when only migration changes are required

### DIFF
--- a/src/packages/packagefactory.py
+++ b/src/packages/packagefactory.py
@@ -33,12 +33,17 @@ class PackageFactory(object):
     VERSION_CMD_ALBA = 'alba version --terse'
     VERSION_CMD_ARAKOON = "arakoon --version | grep version: | awk '{print $2}'"
 
-    # Components
+    # Update Components
     COMP_SD = 'storagedriver'
     COMP_FWK = 'framework'
     COMP_ALBA = 'alba'
     COMP_ISCSI = 'iscsi'
     COMP_ARAKOON = 'arakoon'  # This is the only component which cannot be selected via the GUI for update, but is used elsewhere
+
+    # Migration Components
+    COMP_MIGRATION_FWK = 'ovs'
+    COMP_MIGRATION_ALBA = 'alba'
+    COMP_MIGRATION_ISCSI = 'iscsi'
 
     # Editions
     EDITION_COMMUNITY = 'community'

--- a/src/services/servicefactory.py
+++ b/src/services/servicefactory.py
@@ -192,9 +192,13 @@ class ServiceFactory(object):
                 continue
             package_name = version.strip().split('=')[0]
             running_version = version.strip().split('=')[1]
-            if running_version is not None and (LooseVersion(running_version) < binary_versions[package_name] or '-reboot' in running_version):
-                return {'installed': running_version,
-                        'candidate': str(binary_versions[package_name])}
+            if running_version is not None:
+                if LooseVersion(running_version) < binary_versions[package_name]:
+                    return {'installed': running_version,
+                            'candidate': str(binary_versions[package_name])}
+                if '-reboot' in running_version:
+                    return {'installed': 'service_restart',
+                            'candidate': str(binary_versions[package_name])}
 
     @classmethod
     def remove_services_marked_for_removal(cls, client, package_names):


### PR DESCRIPTION
Updates in GUI indicate a migration change only or when only some services need to be restarted