### PR TITLE
Remove the tlog_max_entries constraint. This lets Arakoon decide the default

### DIFF
--- a/src/db/arakoon/arakooninstaller.py
+++ b/src/db/arakoon/arakooninstaller.py
@@ -88,7 +88,7 @@ class ArakoonClusterConfig(object):
         Initializes an empty Cluster Config
         """
         self.plugins = []
-        self._extra_globals = {'tlog_max_entries': 5000}
+        self._extra_globals = {}
         if isinstance(plugins, list):
             self.plugins = plugins
         elif isinstance(plugins, basestring):


### PR DESCRIPTION
Addresses https://github.com/openvstorage/framework-extensions/issues/84