### PR TITLE
standardization api return values

### DIFF
--- a/src/api/decorators/generic.py
+++ b/src/api/decorators/generic.py
@@ -46,8 +46,10 @@ class HTTPRequestGenericDecorators(object):
                 Return the
                 """
                 results = f(*args, **kwargs)
-                return {data_type: results}
-
+                d = {data_type: results}
+                if data_type != 'data':  # no data key present yet
+                    d['data'] = results
+                return d
             return new_function
 
         return wrapper


### PR DESCRIPTION
Attempt to streamline return values of api calls by previously introduced decorator
Previously:
{<insert_key>:data}
starting from now:
{<insert_key: data, 'data': data}
the <insert_key> keys are only added for backwards compatibility