### PR TITLE
Bugfix of the asdmanager config.CACC_LOCATION

### DIFF
--- a/src/constants/config.py
+++ b/src/constants/config.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2018 iNuron NV
+#
+# This file is part of Open vStorage Open Source Edition (OSE),
+# as available from
+#
+#      http://www.openvstorage.org and
+#      http://www.openvstorage.com.
+#
+# This file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+# as published by the Free Software Foundation, in version 3 as it comes
+# in the LICENSE.txt file of the Open vStorage OSE distribution.
+#
+# Open vStorage is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY of any kind.
+"""
+Shared strings
+"""
+
+
+CACC_LOCATION = '/opt/OpenvStorage/config/arakoon_cacc.ini'

--- a/src/generic/configuration/configuration.py
+++ b/src/generic/configuration/configuration.py
@@ -55,7 +55,7 @@ class Configuration(object):
     """
 
     BASE_KEY = '/ovs/framework'
-    CACC_LOCATION = None
+    CACC_LOCATION = CACC_LOCATION
     EDITION_KEY = '{0}/edition'.format(BASE_KEY)
 
     _clients = {}
@@ -415,7 +415,7 @@ class Configuration(object):
             store = cls.get_store_info()
         if store == 'arakoon':
             from ovs_extensions.generic.configuration.clients.arakoon import ArakoonConfiguration
-            instance = ArakoonConfiguration(cacc_location=CACC_LOCATION)
+            instance = ArakoonConfiguration(cacc_location=cls.CACC_LOCATION)
         elif store == 'unittest':
             from ovs_extensions.generic.configuration.clients.mock_keyvalue import ConfigurationMockKeyValue
             instance = ConfigurationMockKeyValue()

--- a/src/generic/configuration/configuration.py
+++ b/src/generic/configuration/configuration.py
@@ -26,6 +26,7 @@ from random import randint
 from subprocess import check_output
 from ovs_extensions.log.logger import Logger
 from ovs_extensions.packages.packagefactory import PackageFactory
+from ovs_extensions.constants.config import CACC_LOCATION
 # Import for backwards compatibility/easier access
 from ovs_extensions.generic.configuration.exceptions import ConfigurationNotFoundException as NotFoundException
 from ovs_extensions.generic.configuration.exceptions import ConfigurationAssertionException  # New exception, not mapping
@@ -414,7 +415,7 @@ class Configuration(object):
             store = cls.get_store_info()
         if store == 'arakoon':
             from ovs_extensions.generic.configuration.clients.arakoon import ArakoonConfiguration
-            instance = ArakoonConfiguration(cacc_location=cls.CACC_LOCATION)
+            instance = ArakoonConfiguration(cacc_location=CACC_LOCATION)
         elif store == 'unittest':
             from ovs_extensions.generic.configuration.clients.mock_keyvalue import ConfigurationMockKeyValue
             instance = ConfigurationMockKeyValue()


### PR DESCRIPTION
ovs_extensions part of a bugfix of the asd-manager after the introduction of AWS S3 disks. Configuration paths have changed and one constant has been overlooked