### PR TITLE
Unify config paths in managers

### DIFF
--- a/src/constants/config.py
+++ b/src/constants/config.py
@@ -13,15 +13,11 @@
 #
 # Open vStorage is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY of any kind.
-
+"""
+Shared strings
+"""
 
 ARAKOON_NAME = 'cacc'
 ARAKOON_NAME_UNITTEST = 'unittest-cacc'
 CACC_LOCATION = '/opt/OpenvStorage/config/arakoon_cacc.ini'
 CONFIG_STORE_LOCATION = '/opt/OpenvStorage/config/framework.json'
-"""
-Shared strings
-"""
-
-
-CACC_LOCATION = '/opt/OpenvStorage/config/arakoon_cacc.ini'

--- a/src/constants/config.py
+++ b/src/constants/config.py
@@ -13,6 +13,12 @@
 #
 # Open vStorage is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY of any kind.
+
+
+ARAKOON_NAME = 'cacc'
+ARAKOON_NAME_UNITTEST = 'unittest-cacc'
+CACC_LOCATION = '/opt/OpenvStorage/config/arakoon_cacc.ini'
+CONFIG_STORE_LOCATION = '/opt/OpenvStorage/config/framework.json'
 """
 Shared strings
 """


### PR DESCRIPTION
Change the 
 ```
opt/<manager>/config/framework.json 
opt/<manager>/config/arakoon_cacc.ini` 
```
to
``` 
opt/OpenvStorage/config/framework.json 
opt/OpenvStorage/config/arakoon_cacc.ini
```
so that manager only nodes can properly communicate with eg. proxies.