### PR TITLE
Reworked import for Unittests to be able to work.

### DIFF
--- a/src/cli/cli.py
+++ b/src/cli/cli.py
@@ -1,0 +1,30 @@
+import click
+from ovs_extensions.generic.unittests import UnitTest
+
+
+@click.command('unittest', help='Run all or a part of the OVS unittest suite')
+@click.argument('action', required=False, default=None, type=click.STRING)
+@click.option('--averages', is_flag=True, default=False)
+def unittest(action, averages):
+    from ovs_extensions.storage.volatilefactory import VolatileFactory
+    from ovs_extensions.storage.persistentfactory import PersistentFactory
+    from ovs_extensions.services.servicefactory import ServiceFactory
+
+    # Clear the stores. It will force to recompute
+    VolatileFactory.store = None
+    PersistentFactory.store = None
+    ServiceFactory.manager = None
+
+    ut = UnitTest('ovs')
+    if not action:
+        ut.run_tests(add_averages=averages)
+    elif action == 'list':
+        ut.list_tests(print_tests=True)
+    else:
+        action = str(action)
+
+        if action.endswith('.py'):
+            filename = action.rstrip('.py')
+        else:
+            filename = action
+        ut.run_tests(filename, add_averages=averages)

--- a/src/constants/scripts.py
+++ b/src/constants/scripts.py
@@ -1,0 +1,2 @@
+
+BASE_SCRIPTS = '/opt/OpenvStorage/scripts/'

--- a/src/storage/persistentfactory.py
+++ b/src/storage/persistentfactory.py
@@ -24,6 +24,7 @@ class PersistentFactory(object):
     """
     The PersistentFactory will generate certain default clients.
     """
+    store = None
 
     @classmethod
     def get_client(cls, client_type=None):
@@ -31,7 +32,7 @@ class PersistentFactory(object):
         Returns a persistent storage client
         :param client_type: Type of store client
         """
-        if not hasattr(cls, 'store') or cls.store is None:
+        if cls.store is None:
             if os.environ.get('RUNNING_UNITTESTS') == 'True':
                 client_type = 'dummy'
 

--- a/src/storage/volatilefactory.py
+++ b/src/storage/volatilefactory.py
@@ -24,12 +24,14 @@ class VolatileFactory(object):
     """
     The VolatileFactory will generate certain default clients.
     """
+    store = None
+
     @classmethod
     def get_client(cls, client_type=None):
         """
         Returns a volatile storage client
         """
-        if not hasattr(cls, 'store') or cls.store is None:
+        if cls.store is None:
             if os.environ.get('RUNNING_UNITTESTS') == 'True':
                 client_type = 'dummy'
             if client_type is None:


### PR DESCRIPTION
Todo:
- Entrypoint is `ovs` but help shows as `Usage: entry.py test [OPTIONS]`. must fix
- Plugins are atm recognized as the folder they are present in. This in `opt/openvstorage/scripts/system`, as the old CLI
  should have worked. More research needs to be done on this though.